### PR TITLE
Fix: Update Status Handling for Image Saving

### DIFF
--- a/lib/gallery_photo_view_wrapper.dart
+++ b/lib/gallery_photo_view_wrapper.dart
@@ -186,10 +186,10 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
                   bool status = false;
                   debugPrint(widget.galleryItems![currentIndex!]);
                   if (widget.galleryItems![currentIndex!].contains('http')) {
-                    await _saveNetworkImage(
+                    status = await _saveNetworkImage(
                         widget.galleryItems![currentIndex!]);
                   } else {
-                    await _saveLocalImage();
+                    status = await _saveLocalImage();
                   }
                   if (!mounted) return;
                   if (status == true) {


### PR DESCRIPTION
This pull request addresses an issue with the status handling during image saving operations in the application. The existing code was not updating the status variable correctly, leading to incorrect messages being displayed to users.