### PR TITLE
Replaced NetworkImage with cached_network_image

### DIFF
--- a/lib/gallery_photo_view_wrapper.dart
+++ b/lib/gallery_photo_view_wrapper.dart
@@ -1,5 +1,6 @@
 import 'multi_image_layout.dart';
 import 'dart:ui' as ui;
+import 'package:cached_network_image/cached_network_image.dart';
 
 class GalleryPhotoViewWrapper extends StatefulWidget {
   GalleryPhotoViewWrapper({
@@ -62,7 +63,7 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
     final String item = widget.galleryItems![index];
     return PhotoViewGalleryPageOptions(
       imageProvider: item.contains('http')
-          ? NetworkImage(item, headers: widget.headers)
+          ? CachedNetworkImageProvider(item, headers: widget.headers)
           : AssetImage(item) as ImageProvider<Object>,
       initialScale: PhotoViewComputedScale.contained,
       minScale: PhotoViewComputedScale.contained * (0.5 + index / 10),

--- a/lib/multi_image_layout.dart
+++ b/lib/multi_image_layout.dart
@@ -12,3 +12,4 @@ export 'image_model.dart';
 export 'package:flutter/rendering.dart';
 export 'package:flutter/services.dart';
 export 'package:dio/dio.dart';
+export 'package:cached_network_image/cached_network_image.dart';

--- a/lib/multi_image_viewer.dart
+++ b/lib/multi_image_viewer.dart
@@ -1,4 +1,5 @@
 import 'multi_image_layout.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class MultiImageViewer extends StatelessWidget {
   const MultiImageViewer({
@@ -38,8 +39,8 @@ class MultiImageViewer extends StatelessWidget {
   /// Width of the image(s).
   final double? width;
 
-  NetworkImage _createNetworkImage(String path) =>
-      NetworkImage(path, headers: networkImageHeaders);
+  CachedNetworkImageProvider _createNetworkImage(String path) =>
+      CachedNetworkImageProvider(path, headers: networkImageHeaders);
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   image_gallery_saver: ^2.0.3
   readmore: ^2.2.0
   dio: ^5.4.0
+  cached_network_image: ^3.3.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
As using network Image there was no offline support to the image gallery. Replacing it with CachedNetworkImageProvider from cached_network_image package , It provides smooth offline experience and also reduces network request.