### PR TITLE
docs: clarify iOS photo library permission requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,17 @@ import 'package:multi_image_layout/multi_image_viewer.dart';
 
 Add the following keys to your Info.plist file, located in `<project root>/ios/Runner/Info.plist`:
 
-* `NSPhotoLibraryAddUsageDescription` - describe why your app needs permission for the photo library. This is called Privacy - Photo Library Usage Description in the visual editor.
+* `NSPhotoLibraryAddUsageDescription` - describe why your app needs permission to save images to the photo library.
+* `NSPhotoLibraryUsageDescription` - describe why your app needs access to the photo library.
+
+Without these keys, iOS may terminate the app when the save action is triggered.
+
+```xml
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>This app saves images to your photo library.</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>This app accesses your photo library to save and manage images.</string>
+```
 
 ### Android
 

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -18,6 +18,10 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app saves images to your photo library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app accesses your photo library to save and manage images.</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## Summary
Updates the README to document the required iOS photo library permissions for
saving images.

## Why
Saving images on iOS requires photo library usage descriptions in
`ios/Runner/Info.plist`. If they are missing, iOS can terminate the app when
the save action is triggered.

## Changes
- Added `NSPhotoLibraryAddUsageDescription`
- Added `NSPhotoLibraryUsageDescription`
- Added an example `Info.plist` snippet
- Added a note explaining the iOS termination behaviour when keys are missing
