### PR TITLE
Feat/video support and playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2.0.0
+
+- Added mixed image and video support in grid layouts and fullscreen viewer.
+- Added `ImageModel.video(...)` for video items.
+- Added `autoPlay` to `MultiImageViewer` with a default value of `true`.
+- Added fullscreen video playback controls including play/pause, mute, elapsed time, total duration, and draggable seek bar.
+- Added zoomable fullscreen video presentation using `PhotoView.customChild`.
+- Added shimmer placeholders for loading network images.
+- Added video badges for video tiles in grid layouts.
+- Added save support for both images and videos.
+- Fixed `enableSave` so the fullscreen save button now respects the parameter.
+- Fixed local save capture by attaching a valid repaint boundary.
+- Added network video cache warm-up and cached replay support for faster repeat playback.
+- Added internal helpers for temporary media file handling and video caching.
+
 # 1.0.0
 
 - Fixed `use_build_context_synchronously` lint by checking `context.mounted`.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,210 @@
-<!-- 
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# multi_image_layout
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+Flexible Flutter layouts for mixed media grids and fullscreen viewing.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-library-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages). 
--->
-# Description
-
-Experience dynamic image layout capabilities with this Flutter package.
-Effortlessly integrate single or multiple images and observe the adaptive layout transformation in real-time.
-Enhanced with caption support for each image, it offers both versatility and precision for developers keen on superior UI experiences.
+`multi_image_layout` lets you render single or multiple media items in adaptive
+layouts, then open them in a fullscreen viewer with captions, save support, and
+media-specific controls.
 
 ![Screenshot_20250430-162040](https://github.com/user-attachments/assets/53622c5f-655e-4162-8369-da0e502267b0)
 
+## Features
 
-## Getting started
+- Adaptive layouts for `1`, `2`, `3`, `4`, and `4+` items
+- Mixed image and video support in the same grid
+- Fullscreen media viewer with swipe navigation
+- Zoomable images
+- Zoomable fullscreen videos
+- Video autoplay with `autoPlay: true` by default
+- Video play/pause, mute, progress bar, elapsed time, and total duration
+- Shimmer loading placeholders for network images
+- Save support for images and videos
+- Video cache warm-up for faster repeat playback
+- Optional captions with expand/collapse support
+
+## Getting Started
+
+Add the package to your project:
+
+```yaml
+dependencies:
+  multi_image_layout: ^1.0.0
+```
+
+Import it:
 
 ```dart
-import 'package:multi_image_layout/multi_image_viewer.dart';
+import 'package:multi_image_layout/multi_image_layout.dart';
 ```
 
 ### iOS
 
-Add the following keys to your Info.plist file, located in `<project root>/ios/Runner/Info.plist`:
-
-* `NSPhotoLibraryAddUsageDescription` - describe why your app needs permission to save images to the photo library.
-* `NSPhotoLibraryUsageDescription` - describe why your app needs access to the photo library.
-
-Without these keys, iOS may terminate the app when the save action is triggered.
+If you use the save action, add these keys to
+`ios/Runner/Info.plist`:
 
 ```xml
 <key>NSPhotoLibraryAddUsageDescription</key>
-<string>This app saves images to your photo library.</string>
+<string>This app saves images and videos to your photo library.</string>
 <key>NSPhotoLibraryUsageDescription</key>
-<string>This app accesses your photo library to save and manage images.</string>
+<string>This app accesses your photo library to save and manage media.</string>
 ```
+
+Without these keys, iOS may terminate the app when save is triggered.
+
+If you plan to load remote media, prefer `https` URLs. If you need `http`
+sources, configure App Transport Security for your app.
 
 ### Android
 
-You need to ask for storage permission to save an image to the gallery. You can handle the storage permission using [flutter_permission_handler](https://pub.dev/packages/permission_handler) package.
-
-* `android.permission.WRITE_EXTERNAL_STORAGE` - Permission for usage of external storage
+If you load remote images or videos, make sure your app has internet access:
 
 ```xml
-<application android:requestLegacyExternalStorage="true" .....>
+<uses-permission android:name="android.permission.INTERNET" />
 ```
+
+If you use the save action, request the appropriate storage or media
+permissions for your target Android version. For older Android versions, that
+may include:
+
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+```
+
+And, where needed:
+
+```xml
+<application android:requestLegacyExternalStorage="true" ...>
+```
+
+Permission handling is app-specific, so you should request it from your app
+layer before calling the save action. A package like
+[`permission_handler`](https://pub.dev/packages/permission_handler) can be used
+for that flow.
 
 ## Usage
 
+### Images only
+
 ```dart
-import 'package:multi_image_layout/multi_image_viewer.dart';
 MultiImageViewer(
-  images: [
+  images: const [
     ImageModel(
-      imageUrl: "https://4.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/4684313123.jpg",
+      imageUrl:
+          "https://4.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/4684313123.jpg",
       caption: "Caption 1",
     ),
     ImageModel(
-      imageUrl: "https://3.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/8719688791.jpg",
+      imageUrl:
+          "https://3.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/8719688791.jpg",
       caption: "Caption 2",
     ),
   ],
-  height: 200,
-  width: 200,
-),
+);
 ```
 
-## 🤝 Contributing
+### Mixed Image and Video
 
-Contributions, issues, and feature requests are welcome!
+```dart
+MultiImageViewer(
+  autoPlay: true,
+  images: const [
+    ImageModel(
+      imageUrl:
+          "https://4.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/4684313123.jpg",
+      caption: "Image caption",
+    ),
+    ImageModel.video(
+      videoUrl:
+          "https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4",
+      caption: "Video caption",
+    ),
+    ImageModel(
+      imageUrl:
+          "https://3.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/8719688791.jpg",
+      caption: "Another image caption",
+    ),
+  ],
+  height: 220,
+);
+```
+
+### Disable Video Autoplay
+
+```dart
+MultiImageViewer(
+  autoPlay: false,
+  images: const [
+    ImageModel.video(
+      videoUrl:
+          "https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4",
+      caption: "Tap to open and play",
+    ),
+  ],
+);
+```
+
+## API Notes
+
+### `ImageModel`
+
+Use `ImageModel(...)` for images:
+
+```dart
+const ImageModel(
+  imageUrl: 'https://example.com/image.jpg',
+  caption: 'An image',
+)
+```
+
+Use `ImageModel.video(...)` for videos:
+
+```dart
+const ImageModel.video(
+  videoUrl: 'https://example.com/video.mp4',
+  caption: 'A video',
+)
+```
+
+### `MultiImageViewer`
+
+Common parameters:
+
+- `images`: media items to render
+- `height`: layout height
+- `width`: optional layout width
+- `gap`: spacing between tiles
+- `radius`: edge corner radius
+- `enableSave`: show or hide the save action in fullscreen
+- `autoPlay`: autoplay videos in the grid and fullscreen viewer
+- `networkImageHeaders`: headers used for remote image and video requests
+- `textStyle`: style for the `+N` overlay
+
+## Fullscreen Video Behavior
+
+When a video is opened fullscreen, the viewer includes:
+
+- play/pause
+- mute/unmute
+- elapsed time
+- total duration
+- draggable seek bar
+- zoom support
+
+Network videos are also warmed into cache to improve repeat playback speed.
+
+## Notes
+
+- The first playback of a remote video can still take time because the player
+  must initialize and buffer the remote media.
+- Cached playback is most noticeable on repeat opens of the same video.
+- Save behavior depends on platform permissions being granted by the host app.
+
+## Contributing
+
+Contributions, issues, and feature requests are welcome.
 
 Feel free to check the [issues page](../../issues/).
 
-## Show your support
-
-Give a 👍 if you like this project!
-
-## 📝 License
+## License
 
 This project is [MIT](./LICENSE) licensed.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,12 +8,16 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - image_gallery_saver_plus (from `.symlinks/plugins/image_gallery_saver_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -24,12 +28,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   image_gallery_saver_plus: e597bf65a7846979417a3eae0763b71b6dfec6c3
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,6 +38,28 @@ class _MyHomePageState extends State<MyHomePage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              const Text("Mixed Image + Video"),
+              const SizedBox(height: 10),
+              MultiImageViewer(
+                autoPlay: true,
+                images: const [
+                  ImageModel(
+                    imageUrl:
+                        "https://4.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/4684313123.jpg",
+                    caption: "Image caption",
+                  ),
+                  ImageModel.video(
+                    videoUrl:
+                        "https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4",
+                    caption: "Video caption",
+                  ),
+                  ImageModel(
+                    imageUrl:
+                        "https://3.img-dpreview.com/files/p/TS250x250~sample_galleries/3800753625/8719688791.jpg",
+                  ),
+                ],
+              ),
+              const SizedBox(height: 30),
               const Text("Single(1) Image"),
               const SizedBox(height: 10),
               MultiImageViewer(

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import path_provider_foundation
 import sqflite_darwin
+import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -155,6 +163,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -479,6 +500,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: transitive
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "9862c67c4661c98f30fe707bc1a4f97d6a0faa76784f485d282668e4651a7ac3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: af0e5b8a7a4876fb37e7cc8cb2a011e82bb3ecfa45844ef672e32cb14a1f259e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -504,5 +565,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/lib/gallery_photo_view_wrapper.dart
+++ b/lib/gallery_photo_view_wrapper.dart
@@ -1,6 +1,9 @@
 // ignore_for_file: use_build_context_synchronously
+import 'src/media_save_helper_stub.dart'
+    if (dart.library.io) 'src/media_save_helper_io.dart' as media_save_helper;
+import 'src/video_cache_helper_stub.dart'
+    if (dart.library.io) 'src/video_cache_helper_io.dart' as video_cache_helper;
 import 'multi_image_layout.dart';
-import 'dart:ui' as ui;
 
 class GalleryPhotoViewWrapper extends StatefulWidget {
   GalleryPhotoViewWrapper({
@@ -10,15 +13,19 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
     this.minScale,
     this.maxScale,
     this.initialIndex,
-    required this.galleryItems,
+    this.galleryItems,
+    this.mediaItems,
     this.captions,
     this.scrollDirection = Axis.horizontal,
     this.headers,
     this.enableSave = true,
-  }) : pageController = PageController(initialPage: initialIndex!);
+    this.autoPlay = true,
+  })  : assert(galleryItems != null || mediaItems != null),
+        pageController = PageController(initialPage: initialIndex ?? 0);
 
   final BoxDecoration? backgroundDecoration;
   final List<String>? galleryItems;
+  final List<ImageModel>? mediaItems;
   final List<String>? captions;
   final Map<String, String>? headers;
   final int? initialIndex;
@@ -28,6 +35,8 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
   final PageController pageController;
   final Axis scrollDirection;
   final bool enableSave;
+  final bool autoPlay;
+
   @override
   State<StatefulWidget> createState() {
     return _GalleryPhotoViewWrapperState();
@@ -35,22 +44,144 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
 }
 
 class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
-  int? currentIndex;
+  late final List<ImageModel> _items;
+  int currentIndex = 0;
   bool showCaptions = false;
-  final GlobalKey _globalKey = GlobalKey();
 
   @override
   void initState() {
-    checkCaptionLength();
-    currentIndex = widget.initialIndex;
     super.initState();
+    _items = widget.mediaItems ??
+        widget.galleryItems!
+            .map((item) => ImageModel(imageUrl: item))
+            .toList(growable: false);
+    currentIndex = widget.initialIndex ?? 0;
+    _checkCaptionLength();
+    _warmVisibleVideoCache();
   }
 
-  void checkCaptionLength() {
-    if (widget.captions != null &&
-        widget.captions!.length == widget.galleryItems!.length) {
+  void _warmVisibleVideoCache() {
+    for (final item in _items
+        .where((item) => item.isVideo && _isNetworkSource(item.sourceUrl))) {
+      video_cache_helper.warmNetworkVideoCache(
+        item.sourceUrl,
+        headers: widget.headers,
+      );
+    }
+  }
+
+  void _checkCaptionLength() {
+    final captions = _captions;
+    if (captions != null && captions.length == _items.length) {
       showCaptions = true;
     }
+  }
+
+  List<String>? get _captions {
+    if (widget.captions != null) {
+      return widget.captions;
+    }
+
+    if (_items
+        .any((item) => item.caption != null && item.caption!.isNotEmpty)) {
+      return _items.map((item) => item.caption ?? '').toList(growable: false);
+    }
+
+    return null;
+  }
+
+  ImageModel get _currentItem => _items[currentIndex];
+
+  bool _isNetworkSource(String path) =>
+      path.startsWith('http://') || path.startsWith('https://');
+
+  String _fileNameFor(ImageModel item) {
+    final parsed = Uri.tryParse(item.sourceUrl);
+    final lastSegment = parsed?.pathSegments.isNotEmpty == true
+        ? parsed!.pathSegments.last
+        : '';
+    if (lastSegment.isNotEmpty) {
+      return lastSegment;
+    }
+    return item.isVideo
+        ? 'video-${DateTime.now().millisecondsSinceEpoch}.mp4'
+        : 'image-${DateTime.now().millisecondsSinceEpoch}.png';
+  }
+
+  Future<bool> _saveImage(ImageModel item) async {
+    if (_isNetworkSource(item.sourceUrl)) {
+      final response = await Dio().get<List<int>>(
+        item.sourceUrl,
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: widget.headers,
+        ),
+      );
+      final result = await ImageGallerySaverPlus.saveImage(
+        Uint8List.fromList(response.data ?? const []),
+        quality: 80,
+        name: _fileNameFor(item),
+      );
+      return result['isSuccess'] == true;
+    }
+
+    final byteData = await rootBundle.load(item.sourceUrl);
+    final result = await ImageGallerySaverPlus.saveImage(
+      byteData.buffer.asUint8List(),
+      quality: 80,
+      name: _fileNameFor(item),
+    );
+    return result['isSuccess'] == true;
+  }
+
+  Future<bool> _saveVideo(ImageModel item) async {
+    final Uint8List bytes;
+    if (_isNetworkSource(item.sourceUrl)) {
+      final response = await Dio().get<List<int>>(
+        item.sourceUrl,
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: widget.headers,
+        ),
+      );
+      bytes = Uint8List.fromList(response.data ?? const []);
+    } else {
+      final byteData = await rootBundle.load(item.sourceUrl);
+      bytes = byteData.buffer.asUint8List();
+    }
+
+    final filePath = (await media_save_helper.writeBytesToTemporaryFile(
+      bytes,
+      _fileNameFor(item),
+    ))
+        .path;
+
+    final result = await ImageGallerySaverPlus.saveFile(
+      filePath,
+      name: _fileNameFor(item),
+    );
+    return result['isSuccess'] == true;
+  }
+
+  Future<void> _saveCurrentItem() async {
+    bool status = false;
+    try {
+      status = _currentItem.isVideo
+          ? await _saveVideo(_currentItem)
+          : await _saveImage(_currentItem);
+    } catch (_) {
+      status = false;
+    }
+
+    if (!context.mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          status ? 'Media saved to gallery' : 'Error saving media',
+        ),
+      ),
+    );
   }
 
   void onPageChanged(int index) {
@@ -61,56 +192,10 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
     }
   }
 
-  PhotoViewGalleryPageOptions _buildItem(BuildContext context, int index) {
-    final String item = widget.galleryItems![index];
-    return PhotoViewGalleryPageOptions(
-      imageProvider: item.contains('http')
-          ? CachedNetworkImageProvider(item, headers: widget.headers)
-          : AssetImage(item) as ImageProvider<Object>,
-      initialScale: PhotoViewComputedScale.contained,
-      minScale: PhotoViewComputedScale.contained * (0.5 + index / 10),
-      maxScale: PhotoViewComputedScale.covered * 4.1,
-      heroAttributes: PhotoViewHeroAttributes(tag: item),
-    );
-  }
-
-  Future<bool> _saveLocalImage() async {
-    RenderRepaintBoundary boundary =
-        _globalKey.currentContext!.findRenderObject() as RenderRepaintBoundary;
-    ui.Image image = await boundary.toImage();
-    ByteData? byteData =
-        await (image.toByteData(format: ui.ImageByteFormat.png));
-    if (byteData != null) {
-      final result = await ImageGallerySaverPlus.saveImage(
-        byteData.buffer.asUint8List(),
-        quality: 80,
-        name: "Image-${DateTime.now()}",
-      );
-      // debugPrint(result.toString());
-      if (result['isSuccess'] == true) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  Future<bool> _saveNetworkImage(String networkImage) async {
-    var response = await Dio()
-        .get(networkImage, options: Options(responseType: ResponseType.bytes));
-    final result = await ImageGallerySaverPlus.saveImage(
-      Uint8List.fromList(response.data),
-      quality: 80,
-      name: "Image-${DateTime.now()}",
-    );
-    debugPrint(result.toString());
-    if (result['isSuccess'] == true) {
-      return true;
-    }
-    return false;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final captions = _captions;
+
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 15, 41, 7),
       body: Container(
@@ -122,50 +207,62 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
           height: MediaQuery.of(context).size.height,
         ),
         child: Stack(
-          alignment:
-              showCaptions ? Alignment.bottomCenter : Alignment.bottomRight,
           children: <Widget>[
-            RepaintBoundary(
-              key: _globalKey,
-              child: PhotoViewGallery.builder(
-                scrollPhysics: const BouncingScrollPhysics(),
-                builder: _buildItem,
-                itemCount: widget.galleryItems!.length,
-                loadingBuilder: widget.loadingBuilder,
-                backgroundDecoration: widget.backgroundDecoration ??
-                    const BoxDecoration(
-                      color: Color.fromARGB(255, 9, 40, 1),
-                    ),
-                pageController: widget.pageController,
-                onPageChanged: onPageChanged,
-                scrollDirection: widget.scrollDirection,
-              ),
+            PageView.builder(
+              controller: widget.pageController,
+              itemCount: _items.length,
+              onPageChanged: onPageChanged,
+              scrollDirection: widget.scrollDirection,
+              itemBuilder: (context, index) {
+                final item = _items[index];
+                if (item.isVideo) {
+                  return _FullscreenVideoPage(
+                    item: item,
+                    headers: widget.headers,
+                    autoPlay: widget.autoPlay,
+                    isActive: index == currentIndex,
+                    backgroundDecoration: widget.backgroundDecoration,
+                  );
+                }
+
+                return _FullscreenImagePage(
+                  item: item,
+                  headers: widget.headers,
+                  loadingBuilder: widget.loadingBuilder,
+                  backgroundDecoration: widget.backgroundDecoration,
+                );
+              },
             ),
-            Container(
-              padding: const EdgeInsets.all(20.0),
-              child: showCaptions
-                  ? ReadMoreText(
-                      widget.captions![currentIndex!],
-                      trimLines: 2,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 17,
+            Positioned(
+              left: 20,
+              right: 20,
+              bottom: _currentItem.isVideo ? 120 : 20,
+              child: Align(
+                alignment:
+                    showCaptions ? Alignment.center : Alignment.centerRight,
+                child: showCaptions
+                    ? ReadMoreText(
+                        captions![currentIndex],
+                        trimLines: 2,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 17,
+                        ),
+                        colorClickableText: Colors.white,
+                        trimMode: TrimMode.Line,
+                        trimCollapsedText: 'Show more',
+                        trimExpandedText: 'Show less',
+                        moreStyle: const TextStyle(
+                            fontSize: 17.0, fontWeight: FontWeight.bold),
+                      )
+                    : Text(
+                        "Item ${currentIndex + 1}",
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 17.0,
+                        ),
                       ),
-                      colorClickableText: Colors.white,
-                      trimMode: TrimMode.Line,
-                      trimCollapsedText: 'Show more',
-                      trimExpandedText: 'Show less',
-                      moreStyle: const TextStyle(
-                          fontSize: 17.0, fontWeight: FontWeight.bold),
-                    )
-                  : Text(
-                      "Image ${currentIndex! + 1}",
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 17.0,
-                        decoration: null,
-                      ),
-                    ),
+              ),
             ),
             Positioned(
               top: 80,
@@ -189,35 +286,392 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
                   constraints: const BoxConstraints(),
                   padding: EdgeInsets.zero,
                   icon: const Icon(Icons.download),
-                  onPressed: () async {
-                    bool status = false;
-                    debugPrint(widget.galleryItems![currentIndex!]);
-                    if (widget.galleryItems![currentIndex!].contains('http')) {
-                      status = await _saveNetworkImage(
-                          widget.galleryItems![currentIndex!]);
-                    } else {
-                      status = await _saveLocalImage();
-                    }
-                    if (!context.mounted) return;
-                    if (status == true) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text("Image saved to gallery"),
-                        ),
-                      );
-                    } else {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text("Error saving image"),
-                        ),
-                      );
-                    }
-                  },
+                  onPressed: _saveCurrentItem,
                 ),
               )
           ],
         ),
       ),
+    );
+  }
+}
+
+class _FullscreenImagePage extends StatelessWidget {
+  const _FullscreenImagePage({
+    required this.item,
+    required this.headers,
+    required this.loadingBuilder,
+    required this.backgroundDecoration,
+  });
+
+  final ImageModel item;
+  final Map<String, String>? headers;
+  final LoadingBuilder? loadingBuilder;
+  final BoxDecoration? backgroundDecoration;
+
+  bool get _isNetworkSource =>
+      item.sourceUrl.startsWith('http://') ||
+      item.sourceUrl.startsWith('https://');
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isNetworkSource) {
+      return PhotoView(
+        imageProvider: CachedNetworkImageProvider(
+          item.sourceUrl,
+          headers: headers,
+        ),
+        loadingBuilder: loadingBuilder,
+        backgroundDecoration: backgroundDecoration ??
+            const BoxDecoration(
+              color: Colors.black,
+            ),
+        initialScale: PhotoViewComputedScale.contained,
+        minScale: PhotoViewComputedScale.contained,
+        maxScale: PhotoViewComputedScale.covered * 4.1,
+        heroAttributes: PhotoViewHeroAttributes(tag: item.sourceUrl),
+      );
+    }
+
+    return PhotoView(
+      imageProvider: AssetImage(item.sourceUrl),
+      backgroundDecoration: backgroundDecoration ??
+          const BoxDecoration(
+            color: Colors.black,
+          ),
+      initialScale: PhotoViewComputedScale.contained,
+      minScale: PhotoViewComputedScale.contained,
+      maxScale: PhotoViewComputedScale.covered * 4.1,
+      heroAttributes: PhotoViewHeroAttributes(tag: item.sourceUrl),
+    );
+  }
+}
+
+class _FullscreenVideoPage extends StatefulWidget {
+  const _FullscreenVideoPage({
+    required this.item,
+    required this.headers,
+    required this.autoPlay,
+    required this.isActive,
+    required this.backgroundDecoration,
+  });
+
+  final ImageModel item;
+  final Map<String, String>? headers;
+  final bool autoPlay;
+  final bool isActive;
+  final BoxDecoration? backgroundDecoration;
+
+  @override
+  State<_FullscreenVideoPage> createState() => _FullscreenVideoPageState();
+}
+
+class _FullscreenVideoPageState extends State<_FullscreenVideoPage> {
+  VideoPlayerController? _controller;
+  bool _isInitializing = true;
+  bool _isMuted = false;
+  bool _hasError = false;
+  bool _isScrubbing = false;
+  Duration _scrubPosition = Duration.zero;
+
+  bool get _isNetworkSource =>
+      widget.item.sourceUrl.startsWith('http://') ||
+      widget.item.sourceUrl.startsWith('https://');
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeController();
+  }
+
+  @override
+  void didUpdateWidget(covariant _FullscreenVideoPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isActive != oldWidget.isActive ||
+        widget.autoPlay != oldWidget.autoPlay) {
+      _syncPlaybackState();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _initializeController() async {
+    try {
+      final VideoPlayerController controller;
+      if (_isNetworkSource) {
+        controller = await video_cache_helper.createNetworkVideoController(
+          widget.item.sourceUrl,
+          headers: widget.headers,
+        );
+      } else {
+        controller = VideoPlayerController.asset(widget.item.sourceUrl);
+      }
+
+      await controller.initialize();
+      await controller.setLooping(true);
+      await controller.setVolume(1);
+
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+
+      setState(() {
+        _controller = controller;
+        _isInitializing = false;
+        _hasError = false;
+      });
+
+      await _syncPlaybackState();
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isInitializing = false;
+        _hasError = true;
+      });
+    }
+  }
+
+  Future<void> _syncPlaybackState() async {
+    if (_controller == null || !_controller!.value.isInitialized) {
+      return;
+    }
+
+    if (widget.isActive && widget.autoPlay) {
+      await _controller!.play();
+    } else {
+      await _controller!.pause();
+    }
+  }
+
+  Future<void> _togglePlayback() async {
+    if (_controller == null || !_controller!.value.isInitialized) {
+      return;
+    }
+
+    if (_controller!.value.isPlaying) {
+      await _controller!.pause();
+    } else {
+      await _controller!.play();
+    }
+
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+    final seconds = duration.inSeconds.remainder(60);
+
+    if (hours > 0) {
+      return '${hours.toString().padLeft(2, '0')}:'
+          '${minutes.toString().padLeft(2, '0')}:'
+          '${seconds.toString().padLeft(2, '0')}';
+    }
+
+    return '${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}';
+  }
+
+  Future<void> _toggleMute() async {
+    if (_controller == null || !_controller!.value.isInitialized) {
+      return;
+    }
+
+    _isMuted = !_isMuted;
+    await _controller!.setVolume(_isMuted ? 0 : 1);
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_hasError) {
+      return const Center(
+        child: Icon(
+          Icons.broken_image_outlined,
+          color: Colors.white54,
+          size: 32,
+        ),
+      );
+    }
+
+    if (_isInitializing ||
+        _controller == null ||
+        !_controller!.value.isInitialized) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        PhotoView.customChild(
+          backgroundDecoration: widget.backgroundDecoration ??
+              const BoxDecoration(
+                color: Colors.black,
+              ),
+          childSize: _controller!.value.size,
+          initialScale: PhotoViewComputedScale.contained,
+          minScale: PhotoViewComputedScale.contained,
+          maxScale: PhotoViewComputedScale.covered * 4.0,
+          child: Center(
+            child: AspectRatio(
+              aspectRatio: _controller!.value.aspectRatio,
+              child: VideoPlayer(_controller!),
+            ),
+          ),
+        ),
+        ValueListenableBuilder<VideoPlayerValue>(
+          valueListenable: _controller!,
+          builder: (context, value, child) {
+            final duration = value.duration;
+            final position = _isScrubbing
+                ? _scrubPosition
+                : value.position > duration
+                    ? duration
+                    : value.position;
+            final maxSeconds = duration.inMilliseconds > 0
+                ? duration.inMilliseconds / 1000
+                : 1.0;
+            final currentSeconds =
+                position.inMilliseconds.clamp(0, duration.inMilliseconds) /
+                    1000;
+
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                Center(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.45),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: IconButton(
+                      iconSize: 38,
+                      color: Colors.white,
+                      onPressed: _togglePlayback,
+                      icon: Icon(
+                        value.isPlaying ? Icons.pause : Icons.play_arrow,
+                      ),
+                    ),
+                  ),
+                ),
+                Positioned(
+                  right: 18,
+                  bottom: 86,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.45),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: IconButton(
+                      color: Colors.white,
+                      onPressed: _toggleMute,
+                      icon: Icon(
+                        _isMuted ? Icons.volume_off : Icons.volume_up,
+                      ),
+                    ),
+                  ),
+                ),
+                Positioned(
+                  left: 16,
+                  right: 16,
+                  bottom: 18,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.55),
+                      borderRadius: BorderRadius.circular(18),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SliderTheme(
+                            data: SliderTheme.of(context).copyWith(
+                              trackHeight: 3,
+                              thumbShape: const RoundSliderThumbShape(
+                                enabledThumbRadius: 6,
+                              ),
+                              overlayShape: const RoundSliderOverlayShape(
+                                overlayRadius: 12,
+                              ),
+                            ),
+                            child: Slider(
+                              value: currentSeconds.toDouble(),
+                              min: 0,
+                              max: maxSeconds,
+                              activeColor: Colors.white,
+                              inactiveColor: Colors.white24,
+                              onChanged: (newValue) {
+                                setState(() {
+                                  _isScrubbing = true;
+                                  _scrubPosition = Duration(
+                                    milliseconds: (newValue * 1000).round(),
+                                  );
+                                });
+                              },
+                              onChangeEnd: (newValue) async {
+                                final target = Duration(
+                                  milliseconds: (newValue * 1000).round(),
+                                );
+                                await _controller!.seekTo(target);
+                                if (!mounted) return;
+                                setState(() {
+                                  _isScrubbing = false;
+                                  _scrubPosition = target;
+                                });
+                              },
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            child: Row(
+                              children: [
+                                Text(
+                                  _formatDuration(position),
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const Spacer(),
+                                Text(
+                                  _formatDuration(duration),
+                                  style: const TextStyle(
+                                    color: Colors.white70,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/image_model.dart
+++ b/lib/image_model.dart
@@ -1,6 +1,19 @@
 class ImageModel {
+  const ImageModel({
+    required this.imageUrl,
+    this.caption,
+  }) : videoUrl = null;
+
+  const ImageModel.video({
+    required String this.videoUrl,
+    this.caption,
+  }) : imageUrl = videoUrl;
+
   final String imageUrl;
+  final String? videoUrl;
   final String? caption;
 
-  ImageModel({required this.imageUrl, this.caption});
+  bool get isVideo => videoUrl != null;
+
+  String get sourceUrl => videoUrl ?? imageUrl;
 }

--- a/lib/multi_image_layout.dart
+++ b/lib/multi_image_layout.dart
@@ -13,3 +13,5 @@ export 'package:flutter/rendering.dart';
 export 'package:flutter/services.dart';
 export 'package:dio/dio.dart';
 export 'package:cached_network_image/cached_network_image.dart';
+export 'package:path_provider/path_provider.dart';
+export 'package:video_player/video_player.dart';

--- a/lib/multi_image_viewer.dart
+++ b/lib/multi_image_viewer.dart
@@ -1,3 +1,5 @@
+import 'src/video_cache_helper_stub.dart'
+    if (dart.library.io) 'src/video_cache_helper_io.dart' as video_cache_helper;
 import 'multi_image_layout.dart';
 
 class MultiImageViewer extends StatelessWidget {
@@ -13,11 +15,12 @@ class MultiImageViewer extends StatelessWidget {
     this.width,
     this.networkImageHeaders,
     this.enableSave = true,
+    this.autoPlay = true,
     this.gap = 2,
     this.radius = const Radius.circular(5),
   });
 
-  /// Headers for network image
+  /// Headers for network image and video requests.
   final Map<String, String>? networkImageHeaders;
 
   /// Color of the background image.
@@ -26,16 +29,10 @@ class MultiImageViewer extends StatelessWidget {
   ///Color for the textStyle
   final TextStyle textStyle;
 
-  /// ```List<ImageModel>``` of images and captions to display.
-  ///
-  /// Each image is displayed with respect to its corresponding caption.
-  ///
-  /// Images are compulsory while captions are optional.
+  /// ```List<ImageModel>``` of media and captions to display.
   final List<ImageModel> images;
 
   /// Height of the image(s).
-  ///
-  /// If not set, it will be a height of 205.0.
   final double height;
 
   /// Width of the image(s).
@@ -44,351 +41,511 @@ class MultiImageViewer extends StatelessWidget {
   /// Responsible for displaying download icon button
   final bool enableSave;
 
+  /// Responsible for auto playing videos.
+  final bool autoPlay;
+
   /// Gap between Images in px
   final double gap;
 
   /// Border Radius for edge corners
   final Radius radius;
 
-  CachedNetworkImageProvider _createNetworkImage(String path) =>
-      CachedNetworkImageProvider(path, headers: networkImageHeaders);
+  Widget _buildMediaSurface(
+    ImageModel media,
+    BorderRadius borderRadius, {
+    Widget? overlay,
+  }) {
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: backgroundColor,
+            ),
+          ),
+          Positioned.fill(
+            child: media.isVideo
+                ? _VideoTileSurface(
+                    media: media,
+                    headers: networkImageHeaders,
+                    autoPlay: autoPlay,
+                  )
+                : _ImageTileSurface(
+                    media: media,
+                    headers: networkImageHeaders,
+                  ),
+          ),
+          if (media.isVideo)
+            const Positioned(
+              top: 10,
+              right: 10,
+              child: _VideoBadge(),
+            ),
+          if (overlay != null) Positioned.fill(child: overlay),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTile(
+    BuildContext context,
+    int index,
+    BorderRadius borderRadius, {
+    double? tileWidth,
+    double? tileHeight,
+    Widget? overlay,
+  }) {
+    return GestureDetector(
+      onTap: () => openImage(
+        context,
+        index,
+        images,
+        networkImageHeaders,
+        enableSave,
+        autoPlay,
+      ),
+      child: SizedBox(
+        width: tileWidth,
+        height: tileHeight,
+        child: _buildMediaSurface(
+          images[index],
+          borderRadius,
+          overlay: overlay,
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    /// MediaQuery Width
-    double defaultWidth = MediaQuery.sizeOf(context).width;
-    final imagesList = images.map((image) => image.imageUrl).toList();
-    final captionList = images
-            .any((image) => image.caption != null && image.caption!.isNotEmpty)
-        ? images.map((image) => image.caption ?? '').toList()
-        : null;
+    final double defaultWidth = MediaQuery.sizeOf(context).width;
 
     switch (images.length) {
       case 0:
         return const SizedBox.shrink();
 
       case 1:
-        return GestureDetector(
-          onTap: () => openImage(context, 0, imagesList, captionList,
-              networkImageHeaders, enableSave),
-          child: Container(
-            height: height,
-            width: width ?? defaultWidth,
-            decoration: BoxDecoration(
-              color: backgroundColor,
-              image: DecorationImage(
-                image: _createNetworkImage(images.first.imageUrl),
-                fit: BoxFit.cover,
-              ),
-              borderRadius: BorderRadius.all(radius),
-            ),
-          ),
+        return _buildTile(
+          context,
+          0,
+          BorderRadius.all(radius),
+          tileWidth: width ?? defaultWidth,
+          tileHeight: height,
         );
 
       case 2:
         return SizedBox(
           height: height,
           width: width ?? defaultWidth,
-          child: Row(children: [
-            Expanded(
-              child: GestureDetector(
-                onTap: () => openImage(context, 0, imagesList, captionList,
-                    networkImageHeaders, enableSave),
-                child: Container(
-                  height: height,
-                  width: width == null ? defaultWidth / 2 : width! / 2,
-                  decoration: BoxDecoration(
-                    color: backgroundColor,
-                    image: DecorationImage(
-                        image: _createNetworkImage(images.first.imageUrl),
-                        fit: BoxFit.cover),
-                    borderRadius:
-                        BorderRadius.only(topLeft: radius, bottomLeft: radius),
-                  ),
+          child: Row(
+            children: [
+              Expanded(
+                child: _buildTile(
+                  context,
+                  0,
+                  BorderRadius.only(topLeft: radius, bottomLeft: radius),
+                  tileHeight: height,
                 ),
               ),
-            ),
-            SizedBox(width: gap),
-            Expanded(
-              child: GestureDetector(
-                onTap: () => openImage(context, 1, imagesList, captionList,
-                    networkImageHeaders, enableSave),
-                child: Container(
-                  height: height,
-                  width: width == null ? defaultWidth / 2 : width! / 2,
-                  decoration: BoxDecoration(
-                    color: backgroundColor,
-                    image: DecorationImage(
-                        image: _createNetworkImage(images[1].imageUrl),
-                        fit: BoxFit.cover),
-                    borderRadius: BorderRadius.only(
-                        topRight: radius, bottomRight: radius),
-                  ),
+              SizedBox(width: gap),
+              Expanded(
+                child: _buildTile(
+                  context,
+                  1,
+                  BorderRadius.only(topRight: radius, bottomRight: radius),
+                  tileHeight: height,
                 ),
               ),
-            ),
-          ]),
+            ],
+          ),
         );
 
       case 3:
         return SizedBox(
           height: height,
           width: width ?? defaultWidth,
-          child: Row(children: [
-            Expanded(
-              child: GestureDetector(
-                onTap: () => openImage(context, 0, imagesList, captionList,
-                    networkImageHeaders, enableSave),
-                child: Container(
-                  width: width == null ? defaultWidth / 2 : width! / 2,
-                  decoration: BoxDecoration(
-                    color: backgroundColor,
-                    image: DecorationImage(
-                        image: _createNetworkImage(images.first.imageUrl),
-                        fit: BoxFit.cover),
-                    borderRadius:
-                        BorderRadius.only(topLeft: radius, bottomLeft: radius),
-                  ),
+          child: Row(
+            children: [
+              Expanded(
+                child: _buildTile(
+                  context,
+                  0,
+                  BorderRadius.only(topLeft: radius, bottomLeft: radius),
                 ),
               ),
-            ),
-            SizedBox(width: gap),
-            Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 1, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          image: DecorationImage(
-                              image: _createNetworkImage(images[1].imageUrl),
-                              fit: BoxFit.cover),
-                          borderRadius: BorderRadius.only(topRight: radius),
-                        ),
+              SizedBox(width: gap),
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        1,
+                        BorderRadius.only(topRight: radius),
                       ),
                     ),
-                  ),
-                  SizedBox(height: gap),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 2, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          image: DecorationImage(
-                              image: _createNetworkImage(images[2].imageUrl),
-                              fit: BoxFit.cover),
-                          borderRadius: BorderRadius.only(bottomRight: radius),
-                        ),
+                    SizedBox(height: gap),
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        2,
+                        BorderRadius.only(bottomRight: radius),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ]),
+            ],
+          ),
         );
+
       case 4:
         return SizedBox(
           height: height,
           width: width ?? defaultWidth,
-          child: Row(children: [
-            Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 0, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        // width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                            color: backgroundColor,
-                            image: DecorationImage(
-                                image:
-                                    _createNetworkImage(images.first.imageUrl),
-                                fit: BoxFit.cover),
-                            borderRadius: BorderRadius.only(topLeft: radius)),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        0,
+                        BorderRadius.only(topLeft: radius),
                       ),
                     ),
-                  ),
-                  SizedBox(height: gap),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 2, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                            color: backgroundColor,
-                            image: DecorationImage(
-                                image: _createNetworkImage(images[2].imageUrl),
-                                fit: BoxFit.cover),
-                            borderRadius:
-                                BorderRadius.only(bottomLeft: radius)),
+                    SizedBox(height: gap),
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        2,
+                        BorderRadius.only(bottomLeft: radius),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            SizedBox(width: gap),
-            Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 1, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                            color: backgroundColor,
-                            image: DecorationImage(
-                                image: _createNetworkImage(images[1].imageUrl),
-                                fit: BoxFit.cover),
-                            borderRadius: BorderRadius.only(topRight: radius)),
+              SizedBox(width: gap),
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        1,
+                        BorderRadius.only(topRight: radius),
                       ),
                     ),
-                  ),
-                  SizedBox(height: gap),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 3, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                            color: backgroundColor,
-                            image: DecorationImage(
-                                image: _createNetworkImage(images[3].imageUrl),
-                                fit: BoxFit.cover),
-                            borderRadius:
-                                BorderRadius.only(bottomRight: radius)),
+                    SizedBox(height: gap),
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        3,
+                        BorderRadius.only(bottomRight: radius),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ]),
+            ],
+          ),
         );
 
       default:
         return SizedBox(
           height: height,
           width: width ?? defaultWidth,
-          child: Row(children: [
-            Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 0, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        decoration: BoxDecoration(
-                            color: backgroundColor,
-                            image: DecorationImage(
-                                image:
-                                    _createNetworkImage(images.first.imageUrl),
-                                fit: BoxFit.cover),
-                            borderRadius: BorderRadius.only(topLeft: radius)),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        0,
+                        BorderRadius.only(topLeft: radius),
                       ),
                     ),
-                  ),
-                  SizedBox(height: gap),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 2, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          image: DecorationImage(
-                              image: _createNetworkImage(images[2].imageUrl),
-                              fit: BoxFit.cover),
-                          borderRadius: BorderRadius.only(
-                            bottomLeft: radius,
-                          ),
-                        ),
+                    SizedBox(height: gap),
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        2,
+                        BorderRadius.only(bottomLeft: radius),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            SizedBox(width: gap),
-            Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 1, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          image: DecorationImage(
-                              image: _createNetworkImage(images[1].imageUrl),
-                              fit: BoxFit.cover),
-                          borderRadius: BorderRadius.only(
-                            topRight: radius,
-                          ),
-                        ),
+              SizedBox(width: gap),
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        1,
+                        BorderRadius.only(topRight: radius),
                       ),
                     ),
-                  ),
-                  SizedBox(height: gap),
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () => openImage(context, 3, imagesList,
-                          captionList, networkImageHeaders, enableSave),
-                      child: Container(
-                        width: width == null ? defaultWidth / 2 : width! / 2,
-                        decoration: BoxDecoration(
-                          color: backgroundColor,
-                          image: DecorationImage(
-                              image: _createNetworkImage(images[3].imageUrl),
-                              fit: BoxFit.cover),
-                          borderRadius: BorderRadius.only(
-                            bottomRight: radius,
-                          ),
-                        ),
-                        child: Container(
+                    SizedBox(height: gap),
+                    Expanded(
+                      child: _buildTile(
+                        context,
+                        3,
+                        BorderRadius.only(bottomRight: radius),
+                        overlay: DecoratedBox(
                           decoration: BoxDecoration(
                             color: Colors.black.withValues(alpha: 0.5),
                             borderRadius: BorderRadius.only(
                               bottomRight: radius,
                             ),
                           ),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Colors.black.withValues(alpha: 0.5),
-                              borderRadius: const BorderRadius.only(
-                                bottomRight: Radius.circular(5),
-                              ),
+                          child: Center(
+                            child: Text(
+                              "+${images.length - 4}",
+                              style: textStyle,
                             ),
-                            child: Center(
-                                child: Text("+${images.length - 4}",
-                                    style: textStyle)),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ]),
+            ],
+          ),
         );
     }
+  }
+}
+
+class _ImageTileSurface extends StatelessWidget {
+  const _ImageTileSurface({
+    required this.media,
+    required this.headers,
+  });
+
+  final ImageModel media;
+  final Map<String, String>? headers;
+
+  bool get _isNetworkSource =>
+      media.sourceUrl.startsWith('http://') ||
+      media.sourceUrl.startsWith('https://');
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isNetworkSource) {
+      return CachedNetworkImage(
+        imageUrl: media.sourceUrl,
+        httpHeaders: headers,
+        fit: BoxFit.cover,
+        placeholder: (_, __) => const _ShimmerPlaceholder(),
+        errorWidget: (_, __, ___) => const _ImageErrorPlaceholder(),
+      );
+    }
+
+    return Image.asset(
+      media.sourceUrl,
+      fit: BoxFit.cover,
+      errorBuilder: (_, __, ___) => const _ImageErrorPlaceholder(),
+    );
+  }
+}
+
+class _VideoTileSurface extends StatefulWidget {
+  const _VideoTileSurface({
+    required this.media,
+    required this.headers,
+    required this.autoPlay,
+  });
+
+  final ImageModel media;
+  final Map<String, String>? headers;
+  final bool autoPlay;
+
+  @override
+  State<_VideoTileSurface> createState() => _VideoTileSurfaceState();
+}
+
+class _VideoTileSurfaceState extends State<_VideoTileSurface> {
+  VideoPlayerController? _controller;
+  bool _isReady = false;
+  bool _hasError = false;
+
+  bool get _isNetworkSource =>
+      widget.media.sourceUrl.startsWith('http://') ||
+      widget.media.sourceUrl.startsWith('https://');
+
+  @override
+  void initState() {
+    super.initState();
+    if (_isNetworkSource) {
+      video_cache_helper.warmNetworkVideoCache(
+        widget.media.sourceUrl,
+        headers: widget.headers,
+      );
+    }
+    _initializeController();
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _initializeController() async {
+    try {
+      final VideoPlayerController controller;
+      if (_isNetworkSource) {
+        controller = await video_cache_helper.createNetworkVideoController(
+          widget.media.sourceUrl,
+          headers: widget.headers,
+        );
+      } else {
+        controller = VideoPlayerController.asset(widget.media.sourceUrl);
+      }
+
+      await controller.initialize();
+      await controller.setLooping(true);
+      await controller.setVolume(0);
+      if (widget.autoPlay) {
+        await controller.play();
+      }
+
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+
+      setState(() {
+        _controller = controller;
+        _isReady = true;
+        _hasError = false;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _hasError = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_hasError) {
+      return const _ImageErrorPlaceholder();
+    }
+
+    if (!_isReady || _controller == null || !_controller!.value.isInitialized) {
+      return const _ShimmerPlaceholder();
+    }
+
+    return FittedBox(
+      fit: BoxFit.cover,
+      child: SizedBox(
+        width: _controller!.value.size.width,
+        height: _controller!.value.size.height,
+        child: VideoPlayer(_controller!),
+      ),
+    );
+  }
+}
+
+class _VideoBadge extends StatelessWidget {
+  const _VideoBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Icon(
+          Icons.play_arrow_rounded,
+          color: Colors.white,
+          size: 18,
+        ),
+      ),
+    );
+  }
+}
+
+class _ShimmerPlaceholder extends StatefulWidget {
+  const _ShimmerPlaceholder();
+
+  @override
+  State<_ShimmerPlaceholder> createState() => _ShimmerPlaceholderState();
+}
+
+class _ShimmerPlaceholderState extends State<_ShimmerPlaceholder>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1400),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      child: Container(
+        key: const ValueKey('multi_image_viewer_shimmer'),
+        color: const Color(0xFF1E1E1E),
+      ),
+      builder: (context, child) {
+        final slide = (_controller.value * 2) - 1;
+        return ShaderMask(
+          shaderCallback: (bounds) {
+            return LinearGradient(
+              begin: Alignment(-1.0 - slide, -0.3),
+              end: Alignment(1.0 - slide, 0.3),
+              colors: const [
+                Color(0xFF3A3A3A),
+                Color(0xFFBDBDBD),
+                Color(0xFF3A3A3A),
+              ],
+              stops: const [0.1, 0.45, 0.8],
+            ).createShader(bounds);
+          },
+          blendMode: BlendMode.srcATop,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+class _ImageErrorPlaceholder extends StatelessWidget {
+  const _ImageErrorPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: Color(0xFF1E1E1E),
+      child: Center(
+        child: Icon(
+          Icons.broken_image_outlined,
+          color: Colors.white54,
+          size: 28,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/media_save_helper_io.dart
+++ b/lib/src/media_save_helper_io.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+Future<File> writeBytesToTemporaryFile(
+  Uint8List bytes,
+  String fileName,
+) async {
+  final directory = await getTemporaryDirectory();
+  final file = File('${directory.path}/$fileName');
+  await file.writeAsBytes(bytes, flush: true);
+  return file;
+}

--- a/lib/src/media_save_helper_stub.dart
+++ b/lib/src/media_save_helper_stub.dart
@@ -1,0 +1,9 @@
+import 'dart:typed_data';
+
+Future<dynamic> writeBytesToTemporaryFile(
+  Uint8List bytes,
+  String fileName,
+) {
+  throw UnsupportedError(
+      'Saving video files is not supported on this platform.');
+}

--- a/lib/src/video_cache_helper_io.dart
+++ b/lib/src/video_cache_helper_io.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:video_player/video_player.dart';
+
+class _VideoCacheManager {
+  static final CacheManager instance = CacheManager(
+    Config(
+      'multi_image_viewer_video_cache',
+      stalePeriod: const Duration(days: 14),
+      maxNrOfCacheObjects: 20,
+    ),
+  );
+}
+
+Future<VideoPlayerController> createNetworkVideoController(
+  String url, {
+  Map<String, String>? headers,
+}) async {
+  final cached = await _VideoCacheManager.instance.getFileFromCache(url);
+  if (cached != null) {
+    return VideoPlayerController.file(cached.file);
+  }
+
+  unawaited(
+    _VideoCacheManager.instance.downloadFile(
+      url,
+      authHeaders: headers ?? const {},
+    ),
+  );
+
+  return VideoPlayerController.networkUrl(
+    Uri.parse(url),
+    httpHeaders: headers ?? const {},
+  );
+}
+
+Future<void> warmNetworkVideoCache(
+  String url, {
+  Map<String, String>? headers,
+}) async {
+  final cached = await _VideoCacheManager.instance.getFileFromCache(url);
+  if (cached != null) {
+    return;
+  }
+
+  await _VideoCacheManager.instance.downloadFile(
+    url,
+    authHeaders: headers ?? const {},
+  );
+}

--- a/lib/src/video_cache_helper_stub.dart
+++ b/lib/src/video_cache_helper_stub.dart
@@ -1,0 +1,16 @@
+import 'package:video_player/video_player.dart';
+
+Future<VideoPlayerController> createNetworkVideoController(
+  String url, {
+  Map<String, String>? headers,
+}) async {
+  return VideoPlayerController.networkUrl(
+    Uri.parse(url),
+    httpHeaders: headers ?? const {},
+  );
+}
+
+Future<void> warmNetworkVideoCache(
+  String url, {
+  Map<String, String>? headers,
+}) async {}

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,21 +1,27 @@
 import 'multi_image_layout.dart';
 
-/// View Image(s)
-void openImage(BuildContext context, final int index, List<String> unitImages,
-    List<String>? captions, Map<String, String>? headers, bool enableSave) {
+/// View media item(s)
+void openImage(
+  BuildContext context,
+  int index,
+  List<ImageModel> mediaItems,
+  Map<String, String>? headers,
+  bool enableSave,
+  bool autoPlay,
+) {
   Navigator.push(
     context,
     MaterialPageRoute(
       builder: (context) => GalleryPhotoViewWrapper(
         enableSave: enableSave,
-        galleryItems: unitImages,
-        captions: captions,
+        mediaItems: mediaItems,
         backgroundDecoration: const BoxDecoration(
           color: Colors.black,
         ),
         initialIndex: index,
         scrollDirection: Axis.horizontal,
         headers: headers,
+        autoPlay: autoPlay,
       ),
     ),
   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dio:
     dependency: "direct main"
     description:
@@ -127,7 +135,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
@@ -147,6 +155,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -252,7 +273,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -464,6 +485,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "9862c67c4661c98f30fe707bc1a4f97d6a0faa76784f485d282668e4651a7ac3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: af0e5b8a7a4876fb37e7cc8cb2a011e82bb3ecfa45844ef672e32cb14a1f259e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -489,5 +550,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multi_image_layout
 description: Flexible gallery package for displaying multiple network and asset images in adaptive layouts.
-version: 1.1.0
+version: 2.0.0
 homepage: https://github.com/donaldamadi/multi-image-viewer
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multi_image_layout
 description: Flexible gallery package for displaying multiple network and asset images in adaptive layouts.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/donaldamadi/multi-image-viewer
 
 environment:
@@ -13,6 +13,9 @@ dependencies:
   readmore: ^3.0.0
   dio: ^5.9.0
   cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
+  path_provider: ^2.1.5
+  video_player: ^2.10.1
   flutter:
     sdk: flutter
 

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -3,8 +3,21 @@ import 'package:multi_image_layout/multi_image_layout.dart';
 
 void main() {
   test('ImageModel should hold imageUrl and caption correctly', () {
-    final model = ImageModel(imageUrl: 'testUrl', caption: 'testCaption');
+    final model = const ImageModel(imageUrl: 'testUrl', caption: 'testCaption');
     expect(model.imageUrl, 'testUrl');
+    expect(model.sourceUrl, 'testUrl');
+    expect(model.isVideo, isFalse);
     expect(model.caption, 'testCaption');
+  });
+
+  test('ImageModel.video should flag video content correctly', () {
+    const model = ImageModel.video(
+      videoUrl: 'https://example.com/video.mp4',
+      caption: 'video caption',
+    );
+
+    expect(model.isVideo, isTrue);
+    expect(model.sourceUrl, 'https://example.com/video.mp4');
+    expect(model.caption, 'video caption');
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,6 +2,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:multi_image_layout/multi_image_layout.dart';
 
 void main() {
+  testWidgets('MultiImageViewer shows shimmer while network image loads',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MultiImageViewer(
+            images: [
+              ImageModel(
+                imageUrl: 'https://example.com/image.jpg',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('multi_image_viewer_shimmer')), findsOne);
+  });
+
   testWidgets('GalleryPhotoViewWrapper displays image and caption',
       (WidgetTester tester) async {
     const mockImageUrl = 'assets/images/simple_image.jpeg';


### PR DESCRIPTION
## Summary

This PR evolves `multi_image_layout` from an image-only layout package into a
mixed-media viewer with support for both images and videos.

It adds video support across grid layouts and fullscreen viewing, introduces
autoplay and playback controls, improves loading and save behavior, adds network
video caching for faster repeat playback, and updates the docs and release notes
to reflect the new API and platform requirements.

## What Changed

### Mixed media support
- added support for rendering videos alongside images in grid layouts
- introduced `ImageModel.video(...)` for video items
- updated the fullscreen viewer to handle both images and videos
- preserved existing adaptive layout behavior for 1, 2, 3, 4, and 4+ items

### Video playback
- added `autoPlay` to `MultiImageViewer` with a default value of `true`
- added fullscreen video playback with:
  - play/pause
  - mute/unmute
  - elapsed time
  - total duration
  - draggable seek/progress control
- added zoomable fullscreen video presentation using `PhotoView.customChild`
- added video indicators on video tiles

### Image loading and UX improvements
- added shimmer placeholders for loading network images
- improved caption placement so long captions do not overlap video controls
- kept existing fullscreen image zoom behavior

### Save behavior
- fixed `enableSave` so the fullscreen save button now respects the parameter
- fixed local save capture by attaching a valid repaint boundary
- extended save support to cover both images and videos
- retained platform-dependent save behavior through the host app permissions flow

### Video caching
- added network video cache warm-up
- added cached replay support for faster repeat playback of network videos
- introduced cache-aware controller creation for network video sources

### Docs and release metadata
- updated the README with:
  - mixed image/video usage examples
  - autoplay usage
  - fullscreen video feature notes
  - Android and iOS setup requirements
- updated the changelog to reflect the new release
- bumped the package version to `2.0.0`

## Breaking Changes

This release is versioned as `2.0.0` because the public API has changed in a
breaking way.

- `openImage(...)` no longer uses the previous image-only signature
- the package now exposes a mixed-media flow centered around `ImageModel`

## Platform Notes

### iOS
If save support is used, the host app must define:

- `NSPhotoLibraryAddUsageDescription`
- `NSPhotoLibraryUsageDescription`

### Android
If remote media is used, the host app should include internet access.
If save support is used, the host app must request the appropriate storage/media
permissions for its target Android version.

## Verification

Manual verification recommended for:

- mixed image/video layouts
- fullscreen image viewing
- fullscreen video playback
- autoplay behavior
- seeking and duration display
- caption placement with long captions
- save behavior for image and video items
- reopening previously played network videos to confirm cache benefit

## Notes

- first playback of an uncached remote video may still incur network startup time
- repeat playback should improve once the cache has been populated
- this PR intentionally includes both the feature work and the related README /
  changelog updates so the package can be released cleanly as `2.0.0`
